### PR TITLE
Add Forgot Password form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,8 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import MainPage from './MainPage';
 import CookieConsentComponent from './components/CookieConsentComponent';
 import FilmFestival from './components/FilmFestival';
+import ForgotPasswordPage from './ForgotPasswordPage';
+import PasswordResetConfirmPage from './PasswordResetConfirmPage';
 import { AuthProvider } from './AuthContext';
 
 function App() {
@@ -23,6 +25,8 @@ function App() {
                 </>
               } />
               <Route path="/" element={<FilmFestival />} />
+              <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+              <Route path="/reset-confirm/:uid/:token" element={<PasswordResetConfirmPage />} />
               {/* <Route path="/login" element={<LoginPage />} /> */}
             </Routes>
           </main>

--- a/src/ForgotPasswordPage.js
+++ b/src/ForgotPasswordPage.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Container, Typography, TextField, Button, Alert } from '@mui/material';
+import api from './utils/api';
+
+const ForgotPasswordPage = () => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const apiUrl = process.env.REACT_APP_API_URL;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post(`${apiUrl}/base/api/password-reset/`, { email });
+      setMessage('If the email exists, a reset link has been sent.');
+      setError('');
+    } catch (err) {
+      setError('Failed to send reset email.');
+      setMessage('');
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 4 }}>
+      <Typography variant="h5" component="h1" gutterBottom>
+        Forgot Password
+      </Typography>
+      {message && <Alert severity="success" sx={{ mb: 2 }}>{message}</Alert>}
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      <form onSubmit={handleSubmit}>
+        <TextField
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        />
+        <Button type="submit" variant="contained">
+          Send Reset Link
+        </Button>
+      </form>
+    </Container>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/src/PasswordResetConfirmPage.js
+++ b/src/PasswordResetConfirmPage.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Container, Typography, TextField, Button, Alert } from '@mui/material';
+import api from './utils/api';
+
+const PasswordResetConfirmPage = () => {
+  const { uid, token } = useParams();
+  const [newPassword, setNewPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const apiUrl = process.env.REACT_APP_API_URL;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post(`${apiUrl}/base/reset-confirm/${uid}/${token}/`, { new_password: newPassword });
+      setMessage('Password has been reset. You can now log in.');
+      setError('');
+    } catch (err) {
+      setError('Failed to reset password.');
+      setMessage('');
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 4 }}>
+      <Typography variant="h5" component="h1" gutterBottom>
+        Reset Password
+      </Typography>
+      {message && <Alert severity="success" sx={{ mb: 2 }}>{message}</Alert>}
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {!message && (
+        <form onSubmit={handleSubmit}>
+          <TextField
+            label="New Password"
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            fullWidth
+            margin="normal"
+            required
+          />
+          <Button type="submit" variant="contained">
+            Reset Password
+          </Button>
+        </form>
+      )}
+    </Container>
+  );
+};
+
+export default PasswordResetConfirmPage;
+

--- a/src/components/LoginModal.js
+++ b/src/components/LoginModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../AuthContext';
-import { Typography, Dialog, DialogContent, DialogActions, TextField, Button, Box, Alert } from '@mui/material';
+import { Typography, Dialog, DialogContent, DialogActions, TextField, Button, Box, Alert, Link } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 
 const LoginModal = ({ open, onClose }) => {
   const { login, register } = useAuth();
@@ -117,6 +118,13 @@ const LoginModal = ({ open, onClose }) => {
         <Button onClick={toggleMode} color="secondary">
           {isRegister ? 'Ya tienes cuenta? Login' : "No tienes cuenta? Register"}
         </Button>
+        {!isRegister && (
+          <Box mt={1}>
+            <Link component={RouterLink} to="/forgot-password" underline="hover">
+              Forgot password?
+            </Link>
+          </Box>
+        )}
       </Box>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- add a page to confirm password reset using token from email
- register route for password reset confirmation

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684acd2aed3c8331ae7380d8541eda81